### PR TITLE
Add LegiScan API compliance: caching, hash dedup, budget tracking, an…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ data/
 *.pdf
 !docs/**/*.pdf
 
+# LegiScan API response cache
+.cache/
+
 # Debug
 npm-debug.log*
 yarn-debug.log*

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -23,6 +23,7 @@ interface Source {
   jurisdiction: string;
   source_type: string;
   similarity: number;
+  data_source?: string;
 }
 
 interface ChatResponse {
@@ -72,6 +73,7 @@ export async function POST(request: NextRequest) {
       jurisdiction: chunk.jurisdiction,
       source_type: chunk.source_type,
       similarity: Math.round(chunk.similarity * 100) / 100,
+      data_source: (chunk.metadata?.source as string) || undefined,
     }));
 
     const response: ChatResponse = {

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -22,6 +22,7 @@ interface Source {
   jurisdiction: string;
   source_type: string;
   similarity: number;
+  data_source?: string;
 }
 
 const EXAMPLE_QUESTIONS = [
@@ -153,6 +154,11 @@ export default function ChatPage() {
                         <span className="text-gray-300">
                           ({src.jurisdiction})
                         </span>
+                        {src.data_source === "legiscan" && (
+                          <span className="ml-1 text-gray-300">
+                            — via LegiScan (CC BY 4.0)
+                          </span>
+                        )}
                       </div>
                     ))}
                   </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,6 +43,27 @@ export default function RootLayout({
             Data sourced from Maryland General Assembly, Harford County, and
             Town of Bel Air public records.
           </p>
+          <p className="mt-1">
+            Legislative data provided by{" "}
+            <a
+              href="https://legiscan.com"
+              className="underline hover:text-gray-700"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              LegiScan
+            </a>
+            {" "}and licensed under{" "}
+            <a
+              href="https://creativecommons.org/licenses/by/4.0/"
+              className="underline hover:text-gray-700"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Creative Commons Attribution 4.0
+            </a>
+            .
+          </p>
         </footer>
       </body>
     </html>

--- a/src/ingestion/clients/legiscan.py
+++ b/src/ingestion/clients/legiscan.py
@@ -6,12 +6,23 @@ LegiScan provides full bill text, roll call votes, and amendment tracking
 that Open States may not have.
 
 API docs: https://legiscan.com/legiscan
+Data licensed under Creative Commons Attribution 4.0 (CC BY 4.0).
+
+Compliance with LegiScan API terms:
+  - 30,000 queries/month limit with budget tracking and 80% warning
+  - Local JSON caching of all API responses to minimize query spend
+  - change_hash comparison to skip unchanged bills
+  - dataset_hash comparison to skip unchanged session datasets
+  - Status code ("OK" / "ERROR") checked on every response
 
 @spec INGEST-API-003, INGEST-API-004
 """
 
 import json
 import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import requests
@@ -28,6 +39,22 @@ logger = logging.getLogger(__name__)
 
 BASE_URL = "https://api.legiscan.com"
 MARYLAND_STATE_ID = 20  # LegiScan state ID for Maryland
+MONTHLY_QUERY_LIMIT = 30_000
+QUERY_WARNING_THRESHOLD = 0.80  # Warn at 80% of monthly limit
+
+# Local cache directory for LegiScan API responses
+CACHE_DIR = Path(os.environ.get(
+    "LEGISCAN_CACHE_DIR",
+    Path(__file__).parent.parent.parent.parent / ".cache" / "legiscan",
+))
+
+
+class LegiScanError(Exception):
+    """Raised when the LegiScan API returns an ERROR status."""
+
+
+class LegiScanBudgetWarning(UserWarning):
+    """Warning emitted when API query budget approaches the monthly limit."""
 
 
 class LegiScanClient:
@@ -36,27 +63,170 @@ class LegiScanClient:
 
     Free tier: 30,000 queries/month. Supports bill search, detail,
     full text, roll calls, and bulk session datasets.
+
+    All responses are cached locally as JSON files to avoid redundant
+    queries. Uses LegiScan's change_hash and dataset_hash to detect
+    changes and skip fetches when data hasn't been updated.
     """
 
     def __init__(self):
         config = get_config()
         self.api_key = config.legiscan_api_key
         self.session = requests.Session()
+        self._query_count = 0
+        self._cache_dir = CACHE_DIR
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Load persisted query count for current month
+        self._budget_file = self._cache_dir / "query_budget.json"
+        self._load_query_budget()
+
+    # ─── Query Budget Tracking ────────────────────────────────────────
+
+    def _load_query_budget(self) -> None:
+        """Load the current month's query count from disk."""
+        current_month = datetime.now(timezone.utc).strftime("%Y-%m")
+        if self._budget_file.exists():
+            try:
+                data = json.loads(self._budget_file.read_text())
+                if data.get("month") == current_month:
+                    self._query_count = data.get("count", 0)
+                else:
+                    # New month — reset counter
+                    self._query_count = 0
+                    self._save_query_budget()
+            except (json.JSONDecodeError, KeyError):
+                self._query_count = 0
+        else:
+            self._query_count = 0
+
+    def _save_query_budget(self) -> None:
+        """Persist the current month's query count to disk."""
+        current_month = datetime.now(timezone.utc).strftime("%Y-%m")
+        self._budget_file.write_text(json.dumps({
+            "month": current_month,
+            "count": self._query_count,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }))
+
+    def _check_budget(self) -> None:
+        """Warn if approaching the monthly query limit."""
+        if self._query_count >= MONTHLY_QUERY_LIMIT:
+            raise LegiScanError(
+                f"Monthly query budget exhausted ({self._query_count}/{MONTHLY_QUERY_LIMIT}). "
+                "Queries reset on the 1st of each month."
+            )
+        if self._query_count >= int(MONTHLY_QUERY_LIMIT * QUERY_WARNING_THRESHOLD):
+            logger.warning(
+                "LegiScan API budget warning: %d/%d queries used (%.0f%%). "
+                "Queries reset on the 1st of each month.",
+                self._query_count, MONTHLY_QUERY_LIMIT,
+                (self._query_count / MONTHLY_QUERY_LIMIT) * 100,
+            )
+
+    @property
+    def queries_used(self) -> int:
+        """Number of API queries used this month."""
+        return self._query_count
+
+    @property
+    def queries_remaining(self) -> int:
+        """Number of API queries remaining this month."""
+        return max(0, MONTHLY_QUERY_LIMIT - self._query_count)
+
+    # ─── Local Response Cache ─────────────────────────────────────────
+
+    def _cache_path(self, op: str, **kwargs: Any) -> Path:
+        """Generate a deterministic cache file path for an API operation."""
+        parts = [op] + [f"{k}={v}" for k, v in sorted(kwargs.items())]
+        filename = "_".join(str(p) for p in parts) + ".json"
+        return self._cache_dir / op / filename
+
+    def _read_cache(self, cache_path: Path) -> dict | None:
+        """Read a cached API response from disk. Returns None if not cached."""
+        if cache_path.exists():
+            try:
+                return json.loads(cache_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                return None
+        return None
+
+    def _write_cache(self, cache_path: Path, data: dict) -> None:
+        """Write an API response to the local cache."""
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(data, default=str))
+
+    # ─── API Request Layer ────────────────────────────────────────────
 
     def _get(self, params: dict[str, Any]) -> dict:
-        """Make an authenticated API request."""
+        """
+        Make an authenticated API request.
+
+        Always checks the status code in the JSON response for "OK" or "ERROR"
+        as required by LegiScan API terms.
+        """
+        self._check_budget()
+
         params["key"] = self.api_key
         response = self.session.get(BASE_URL, params=params)
         response.raise_for_status()
         data = response.json()
-        if data.get("status") == "ERROR":
-            raise RuntimeError(f"LegiScan API error: {data.get('alert', {}).get('message', 'unknown')}")
+
+        # Track query spend
+        self._query_count += 1
+        self._save_query_budget()
+
+        # LegiScan API terms: always check status code in JSON response
+        status = data.get("status")
+        if status == "ERROR":
+            alert = data.get("alert", {})
+            msg = alert.get("message", "Unknown error") if isinstance(alert, dict) else str(alert)
+            raise LegiScanError(f"LegiScan API error: {msg}")
+        if status != "OK":
+            logger.warning("Unexpected LegiScan status: %s (expected OK or ERROR)", status)
+
         return data
+
+    # ─── Hash-Based Change Detection ──────────────────────────────────
+
+    def _get_stored_hashes(self, hash_type: str) -> dict[str, str]:
+        """Load stored hashes (change_hash or dataset_hash) from cache."""
+        hash_file = self._cache_dir / f"{hash_type}_hashes.json"
+        if hash_file.exists():
+            try:
+                return json.loads(hash_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                return {}
+        return {}
+
+    def _save_stored_hashes(self, hash_type: str, hashes: dict[str, str]) -> None:
+        """Persist hashes to disk for future comparison."""
+        hash_file = self._cache_dir / f"{hash_type}_hashes.json"
+        hash_file.write_text(json.dumps(hashes))
+
+    # ─── Public API Methods ───────────────────────────────────────────
 
     def get_session_list(self) -> list[dict]:
         """Get available Maryland legislative sessions."""
+        cache_path = self._cache_path("getSessionList", state="MD")
+        cached = self._read_cache(cache_path)
+        if cached is not None:
+            return cached.get("sessions", [])
+
         data = self._get({"op": "getSessionList", "state": "MD"})
+        self._write_cache(cache_path, data)
         return data.get("sessions", [])
+
+    def get_master_list_raw(self, session_id: int) -> dict:
+        """
+        Get the raw master list for a session including change_hash values.
+
+        Uses getMasterListRaw as recommended by LegiScan API terms for
+        efficient polling — returns bill_id + change_hash pairs to detect
+        which bills have changed since last fetch.
+        """
+        data = self._get({"op": "getMasterListRaw", "id": session_id})
+        return data.get("masterlist", {})
 
     def get_master_list(self, session_id: int) -> dict:
         """
@@ -68,12 +238,26 @@ class LegiScanClient:
 
     def get_bill(self, bill_id: int) -> dict:
         """Get full bill detail including history, sponsors, texts, votes."""
+        # Check cache first
+        cache_path = self._cache_path("getBill", id=bill_id)
+        cached = self._read_cache(cache_path)
+        if cached is not None:
+            return cached.get("bill", cached)
+
         data = self._get({"op": "getBill", "id": bill_id})
+        self._write_cache(cache_path, data)
         return data.get("bill", {})
 
     def get_bill_text(self, doc_id: int) -> dict:
-        """Get the full text of a bill document."""
+        """Get the full text of a bill document (Base64 encoded)."""
+        # Check cache — bill text blobs don't need to be downloaded more than once
+        cache_path = self._cache_path("getBillText", id=doc_id)
+        cached = self._read_cache(cache_path)
+        if cached is not None:
+            return cached.get("text", cached)
+
         data = self._get({"op": "getBillText", "id": doc_id})
+        self._write_cache(cache_path, data)
         return data.get("text", {})
 
     def search_bills(self, query: str, state: str = "MD", page: int = 1) -> dict:
@@ -86,10 +270,100 @@ class LegiScanClient:
         })
         return data.get("searchresult", {})
 
+    def get_dataset_list(self, session_id: int) -> list[dict]:
+        """Get available dataset archives for a session."""
+        data = self._get({"op": "getDatasetList", "state": "MD", "id": session_id})
+        return data.get("datasetlist", [])
+
+    def get_dataset(self, dataset_id: int) -> dict:
+        """Get a dataset archive (Base64 encoded ZIP)."""
+        # Check dataset_hash before downloading
+        stored_hashes = self._get_stored_hashes("dataset")
+        cache_path = self._cache_path("getDataset", id=dataset_id)
+        cached = self._read_cache(cache_path)
+        if cached is not None:
+            return cached.get("dataset", cached)
+
+        data = self._get({"op": "getDataset", "id": dataset_id})
+        self._write_cache(cache_path, data)
+        return data.get("dataset", {})
+
+    # ─── Smart Ingestion with Hash Comparison ─────────────────────────
+
+    def get_changed_bills(self, session_id: int) -> list[int]:
+        """
+        Use getMasterListRaw to detect which bills have changed since
+        last fetch, by comparing change_hash values.
+
+        Returns list of bill_ids that need to be re-fetched.
+
+        This is the recommended LegiScan work loop pattern:
+        check getMasterListRaw periodically → compare change_hash →
+        only spend queries on bills that have actually changed.
+        """
+        raw_list = self.get_master_list_raw(session_id)
+        stored_hashes = self._get_stored_hashes("change")
+        changed_bill_ids = []
+
+        for key, entry in raw_list.items():
+            if key == "session":
+                continue  # Skip session metadata
+
+            bill_id = str(entry.get("bill_id", ""))
+            change_hash = entry.get("change_hash", "")
+            if not bill_id:
+                continue
+
+            # Compare with stored hash — only fetch if hash differs
+            if stored_hashes.get(bill_id) != change_hash:
+                changed_bill_ids.append(int(bill_id))
+                stored_hashes[bill_id] = change_hash
+
+        # Save updated hashes
+        self._save_stored_hashes("change", stored_hashes)
+
+        logger.info(
+            "change_hash comparison: %d/%d bills changed since last check",
+            len(changed_bill_ids),
+            sum(1 for k in raw_list if k != "session"),
+        )
+        return changed_bill_ids
+
+    def check_dataset_changed(self, session_id: int) -> tuple[bool, int | None]:
+        """
+        Check if the session dataset has changed by comparing dataset_hash.
+
+        Returns (has_changed, dataset_id) tuple.
+        """
+        datasets = self.get_dataset_list(session_id)
+        if not datasets:
+            return False, None
+
+        latest = datasets[0]  # Most recent dataset
+        dataset_id = latest.get("dataset_id")
+        dataset_hash = latest.get("dataset_hash", "")
+        session_key = str(session_id)
+
+        stored_hashes = self._get_stored_hashes("dataset")
+        if stored_hashes.get(session_key) == dataset_hash:
+            logger.info(
+                "dataset_hash unchanged for session %s — skipping download",
+                session_id,
+            )
+            return False, dataset_id
+
+        # Update stored hash
+        stored_hashes[session_key] = dataset_hash
+        self._save_stored_hashes("dataset", stored_hashes)
+        return True, dataset_id
+
 
 def ingest_legiscan_bills(session_id: int | None = None) -> None:
     """
     Ingest Maryland bills from LegiScan into the Bronze layer.
+
+    Uses change_hash comparison to only fetch bills that have changed
+    since the last ingestion run, minimizing API query spend.
 
     If session_id is not provided, uses the most recent session.
 
@@ -108,18 +382,18 @@ def ingest_legiscan_bills(session_id: int | None = None) -> None:
             session_id = sessions[0]["session_id"]
             logger.info(f"Using most recent session: {sessions[0].get('session_name', session_id)}")
 
-        # Get master bill list for the session
-        master_list = client.get_master_list(session_id)
+        # Use change_hash to find only bills that have changed
+        changed_bill_ids = client.get_changed_bills(session_id)
+
+        if not changed_bill_ids:
+            logger.info("No bills changed since last check — skipping ingestion")
+            complete_ingestion_run(db, run_id, records_fetched=0)
+            return
+
+        logger.info(f"Fetching {len(changed_bill_ids)} changed bills (of session {session_id})")
         fetched = 0
 
-        for key, bill_summary in master_list.items():
-            if key == "session":
-                continue  # Skip session metadata entry
-
-            bill_id = bill_summary.get("bill_id")
-            if not bill_id:
-                continue
-
+        for bill_id in changed_bill_ids:
             # Fetch full bill detail
             bill_detail = client.get_bill(bill_id)
             raw_content = json.dumps(bill_detail, default=str)
@@ -134,6 +408,8 @@ def ingest_legiscan_bills(session_id: int | None = None) -> None:
                     "bill_number": bill_detail.get("bill_number", ""),
                     "session_id": session_id,
                     "state": "MD",
+                    "change_hash": bill_detail.get("change_hash", ""),
+                    "legiscan_attribution": "Data provided by LegiScan (CC BY 4.0)",
                 },
                 url=bill_detail.get("url"),
             )
@@ -141,7 +417,10 @@ def ingest_legiscan_bills(session_id: int | None = None) -> None:
             logger.info(f"Ingested LegiScan bill {bill_detail.get('bill_number', bill_id)}")
 
         complete_ingestion_run(db, run_id, records_fetched=fetched)
-        logger.info(f"LegiScan ingestion complete: {fetched} bills fetched")
+        logger.info(
+            f"LegiScan ingestion complete: {fetched} bills fetched. "
+            f"API budget: {client.queries_used}/{MONTHLY_QUERY_LIMIT} queries used this month."
+        )
 
     except Exception as e:
         logger.error(f"LegiScan ingestion failed: {e}")

--- a/supabase/migrations/003_legiscan_compliance.sql
+++ b/supabase/migrations/003_legiscan_compliance.sql
@@ -1,0 +1,43 @@
+-- CivicLens: LegiScan API compliance — hash tracking and attribution
+-- Migration: 003_legiscan_compliance
+-- Date: 2026-03-16
+--
+-- Adds LegiScan-specific columns to support API compliance:
+-- 1. legiscan_change_hash: 32-char hash from LegiScan for bill change detection
+-- 2. legiscan_dataset_hash: 32-char hash from LegiScan for dataset change detection
+-- 3. data_source_attribution: Human-readable attribution string (CC BY 4.0)
+
+-- Add LegiScan change_hash to bronze_documents for hash-based dedup
+alter table bronze_documents
+    add column if not exists legiscan_change_hash text;
+
+comment on column bronze_documents.legiscan_change_hash is
+    'LegiScan change_hash (32 chars) for bill change detection. '
+    'Compare before fetching to avoid unnecessary API queries.';
+
+-- Index for fast hash lookups when comparing against master list
+create index if not exists idx_bronze_legiscan_hash
+    on bronze_documents(legiscan_change_hash)
+    where source = 'legiscan';
+
+-- Track dataset hashes per session for bulk download dedup
+create table if not exists legiscan_dataset_hashes (
+    session_id integer primary key,
+    dataset_hash text not null,        -- 32-char hash from getDatasetList
+    dataset_id integer,                -- LegiScan dataset ID
+    checked_at timestamptz not null default now(),
+    downloaded_at timestamptz          -- null if hash matched and download was skipped
+);
+
+comment on table legiscan_dataset_hashes is
+    'Tracks LegiScan dataset_hash per session to prevent duplicative '
+    'downloads. Per API terms: failure to use dataset_hash will result '
+    'in suspended access.';
+
+-- Add source attribution to document_chunks metadata convention.
+-- This is informational — the actual attribution is stored in
+-- document_chunks.metadata->>'source' during the embedding pipeline.
+comment on column document_chunks.metadata is
+    'Flexible metadata for retrieval filtering. '
+    'For LegiScan-sourced chunks, includes "source": "legiscan" '
+    'for CC BY 4.0 attribution in the UI.';


### PR DESCRIPTION
…d CC BY 4.0 attribution

Brings the LegiScan integration into compliance with API terms of service:
- Local JSON response caching to minimize query spend
- change_hash comparison via getMasterListRaw to skip unchanged bills
- dataset_hash comparison to prevent duplicative dataset downloads
- Query budget tracking (30K/month) with warning at 80% threshold
- Status code (OK/ERROR) validation on every API response
- CC BY 4.0 attribution in site footer and per-source chat citations
- New migration for legiscan_change_hash column and dataset hash table