### PR TITLE
Fix Set iteration build error by using Array.from()

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/lib/rag.ts
+++ b/src/lib/rag.ts
@@ -103,7 +103,7 @@ export async function retrieveContext(
 
   // Compute context metadata for model routing
   const uniqueDocIds = new Set(chunks.map((c) => c.source_id));
-  const jurisdictions = [...new Set(chunks.map((c) => c.jurisdiction))];
+  const jurisdictions = Array.from(new Set(chunks.map((c) => c.jurisdiction)));
 
   return {
     chunks,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,13 +15,27 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Replaced spread syntax on Set with Array.from() in rag.ts to fix TypeScript compilation error with ES5 target. Also includes tsconfig updates from Next.js build (jsx: react-jsx, expanded include paths).