### PR TITLE
Fix Python 3.9 compatibility and OpenStates API include parameter

### DIFF
--- a/src/ingestion/clients/legiscan.py
+++ b/src/ingestion/clients/legiscan.py
@@ -18,6 +18,8 @@ Compliance with LegiScan API terms:
 @spec INGEST-API-003, INGEST-API-004
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/src/ingestion/clients/openstates.py
+++ b/src/ingestion/clients/openstates.py
@@ -9,6 +9,8 @@ API docs: https://docs.openstates.org/api-v3/
 @spec INGEST-API-001, INGEST-API-002
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Any, Generator
 
@@ -74,7 +76,7 @@ class OpenStatesClient:
             "jurisdiction": MARYLAND_JURISDICTION,
             "page": page,
             "per_page": min(per_page, 50),
-            "include": "abstracts,actions,sponsorships,sources",
+            "include": ["abstracts", "actions", "sponsorships", "sources"],
         }
         if session:
             params["session"] = session

--- a/src/ingestion/scrapers/belair_legislation.py
+++ b/src/ingestion/scrapers/belair_legislation.py
@@ -11,6 +11,8 @@ links to PDF documents in the CivicPlus DocumentCenter.
 @spec INGEST-SCRAPE-003
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import time

--- a/src/ingestion/scrapers/ecode360.py
+++ b/src/ingestion/scrapers/ecode360.py
@@ -11,6 +11,8 @@ and generates section_path breadcrumbs for RAG retrieval context.
 @spec INGEST-SCRAPE-001, INGEST-SCRAPE-002
 """
 
+from __future__ import annotations
+
 import logging
 import time
 from dataclasses import dataclass

--- a/src/lib/models.py
+++ b/src/lib/models.py
@@ -8,6 +8,7 @@ to the Silver layer.
 
 from datetime import date, datetime
 from enum import Enum
+from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -69,20 +70,20 @@ class LegislativeItem(BaseModel):
     """
 
     id: UUID = Field(default_factory=uuid4)
-    bronze_id: str | None = None
+    bronze_id: Optional[str] = None
     source_id: str
     jurisdiction: JurisdictionLevel
     body: str  # e.g., "Maryland General Assembly", "Harford County Council"
     item_type: LegislativeType
     title: str
-    summary: str | None = None
+    summary: Optional[str] = None
     status: LegislativeStatus = LegislativeStatus.UNKNOWN
-    introduced_date: date | None = None
-    last_action_date: date | None = None
-    last_action: str | None = None
-    sponsors: list[str] = Field(default_factory=list)
-    source_url: str | None = None
-    tags: list[str] = Field(default_factory=list)
+    introduced_date: Optional[date] = None
+    last_action_date: Optional[date] = None
+    last_action: Optional[str] = None
+    sponsors: List[str] = Field(default_factory=list)
+    source_url: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
 
 
 class CodeSection(BaseModel):
@@ -96,18 +97,18 @@ class CodeSection(BaseModel):
     """
 
     id: UUID = Field(default_factory=uuid4)
-    bronze_id: str | None = None
+    bronze_id: Optional[str] = None
     jurisdiction: JurisdictionLevel
     code_source: str  # "Harford County Code" or "Town of Bel Air Code"
     chapter: str
     section: str
     title: str
     content: str
-    parent_section_id: UUID | None = None
-    section_path: str | None = None  # "Town Code > Ch. 165 > §165-23"
-    source_url: str | None = None
-    effective_date: date | None = None
-    last_amended: date | None = None
+    parent_section_id: Optional[UUID] = None
+    section_path: Optional[str] = None  # "Town Code > Ch. 165 > §165-23"
+    source_url: Optional[str] = None
+    effective_date: Optional[date] = None
+    last_amended: Optional[date] = None
 
 
 class MeetingRecord(BaseModel):
@@ -118,15 +119,15 @@ class MeetingRecord(BaseModel):
     """
 
     id: UUID = Field(default_factory=uuid4)
-    bronze_id: str | None = None
+    bronze_id: Optional[str] = None
     jurisdiction: JurisdictionLevel
     body: str  # "Board of Town Commissioners", "Planning Commission", etc.
     meeting_date: date
     record_type: str  # "agenda" or "minutes"
-    title: str | None = None
-    content: str | None = None  # Extracted text (may be null pre-PDF extraction)
-    pdf_url: str | None = None
-    source_url: str | None = None
+    title: Optional[str] = None
+    content: Optional[str] = None  # Extracted text (may be null pre-PDF extraction)
+    pdf_url: Optional[str] = None
+    source_url: Optional[str] = None
 
 
 # ─── Gold Layer Models ──────────────────────────────────────────────────
@@ -148,6 +149,6 @@ class DocumentChunk(BaseModel):
     jurisdiction: JurisdictionLevel
     chunk_text: str
     chunk_index: int = 0
-    section_path: str | None = None
-    embedding: list[float] | None = None  # Set during embedding generation
-    metadata: dict = Field(default_factory=dict)
+    section_path: Optional[str] = None
+    embedding: Optional[List[float]] = None  # Set during embedding generation
+    metadata: Dict = Field(default_factory=dict)

--- a/src/lib/supabase.py
+++ b/src/lib/supabase.py
@@ -4,6 +4,8 @@ Supabase client for Python ingestion and pipeline scripts.
 Provides typed helpers for Bronze/Silver/Gold layer operations.
 """
 
+from __future__ import annotations
+
 import hashlib
 from datetime import datetime, timezone
 from typing import Any

--- a/src/pipeline/embedder.py
+++ b/src/pipeline/embedder.py
@@ -12,6 +12,8 @@ bounded by section numbers.
 @spec DATA-EMBED-001, DATA-EMBED-002, DATA-EMBED-003
 """
 
+from __future__ import annotations
+
 import logging
 import re
 from typing import Any

--- a/src/pipeline/normalize.py
+++ b/src/pipeline/normalize.py
@@ -10,6 +10,8 @@ fields to the unified data model.
 @spec DATA-PIPE-001, DATA-PIPE-002
 """
 
+from __future__ import annotations
+
 import json
 import logging
 from datetime import date


### PR DESCRIPTION
Add `from __future__ import annotations` to 7 Python files and use `Optional`/`List`/`Dict` from typing in Pydantic models to support Python 3.9 (which lacks PEP 604 `X | None` syntax). Also fix the OpenStates `/bills` include parameter to use a list instead of a comma-separated string, matching the API's expected array format.