### PR TITLE
Add OCR fallback for scanned PDF ingestion via pytesseract

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,9 @@ feedparser>=6.0.0          # RSS feed parsing
 
 # ─── PDF Extraction ─────────────────────────────────────────────────
 pdfplumber>=0.11.0         # PDF text/table extraction
-# pytesseract>=0.3.10     # OCR — uncomment when Tier 3 PDF work begins
+pytesseract>=0.3.10        # OCR for scanned PDFs (requires: brew install tesseract)
+pdf2image>=1.17.0          # PDF page → PIL image conversion (requires: poppler)
+Pillow>=10.0.0             # Image processing for OCR pipeline
 
 # ─── Database ────────────────────────────────────────────────────────
 supabase>=2.5.0            # Supabase Python client

--- a/src/ingestion/extractors/pdf_extractor.py
+++ b/src/ingestion/extractors/pdf_extractor.py
@@ -1,32 +1,193 @@
 """
-PDF text extraction pipeline — stub for Phase 4.
+PDF text extraction with OCR fallback for scanned documents.
 
-Extracts text from PDF documents (meeting agendas, minutes, ordinance
-text, fiscal notes) using pdfplumber for machine-generated PDFs and
-Tesseract OCR as a fallback for scanned documents.
+Uses pdfplumber as the primary extractor for machine-generated PDFs.
+Falls back to pytesseract OCR (via pdf2image) for scanned/image-only pages.
 
 @spec INGEST-PDF-001, INGEST-PDF-002
 """
 
+from __future__ import annotations
+
+import functools
+import io
 import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import pdfplumber
 
 logger = logging.getLogger(__name__)
 
-# TODO: Implement in Phase 4
-# - pdfplumber-based text extraction for well-formed PDFs
-# - Tesseract OCR fallback for scanned documents
-# - Document type classification (agenda, minutes, ordinance text, fiscal note)
-# - Structured extraction of agenda items (item number, description, action)
-# - Integration with CivicPlus AgendaCenter scraper (download → extract → Bronze)
+# Minimum text length (characters) to consider a page successfully extracted.
+# Pages below this threshold are treated as scanned/image-only and sent to OCR.
+MIN_PAGE_TEXT_LENGTH = 20
+
+# Separator between pages in the joined output text.
+PAGE_SEPARATOR = "\n\n---\n\n"
+
+# DPI for rendering scanned pages as images for OCR.
+# 300 is the standard for government documents; higher = better quality but more RAM.
+OCR_DPI = 300
+
+# Tesseract config: PSM 6 = single uniform block of text (best for legislative docs),
+# OEM 3 = LSTM engine (best accuracy).
+TESSERACT_CONFIG = "--psm 6 --oem 3"
 
 
-def extract_text_from_pdf(pdf_path: str) -> str:
+@functools.lru_cache(maxsize=1)
+def _check_ocr_available() -> bool:
+    """Check if pytesseract and pdf2image are importable and tesseract is installed."""
+    try:
+        import pytesseract  # noqa: F401
+        from pdf2image import convert_from_bytes, convert_from_path  # noqa: F401
+
+        # Verify tesseract binary is reachable
+        pytesseract.get_tesseract_version()
+        return True
+    except ImportError:
+        logger.warning(
+            "OCR dependencies not installed (pytesseract, pdf2image). "
+            "Install with: pip install pytesseract pdf2image Pillow"
+        )
+        return False
+    except Exception as e:
+        logger.warning(
+            f"Tesseract not available: {e}. "
+            "Install with: brew install tesseract (macOS) or apt install tesseract-ocr (Linux)"
+        )
+        return False
+
+
+def _ocr_page(source: str | Path | bytes, page_number: int) -> str:
+    """OCR a single page from a PDF (file path or in-memory bytes)."""
+    from pdf2image import convert_from_bytes, convert_from_path
+    import pytesseract
+
+    if isinstance(source, bytes):
+        images = convert_from_bytes(
+            source, dpi=OCR_DPI, first_page=page_number, last_page=page_number
+        )
+    else:
+        images = convert_from_path(
+            str(source), dpi=OCR_DPI, first_page=page_number, last_page=page_number
+        )
+    if not images:
+        return ""
+    return pytesseract.image_to_string(images[0], config=TESSERACT_CONFIG).strip()
+
+
+@dataclass
+class ExtractionResult:
+    """Result of PDF text extraction."""
+
+    text: str
+    page_count: int
+    ocr_page_count: int
+
+
+def extract_text(
+    source: str | Path | bytes,
+    *,
+    ocr_enabled: bool = True,
+) -> ExtractionResult:
     """
-    Extract text from a PDF file.
+    Extract text from a PDF, using OCR as fallback for scanned pages.
 
-    Uses pdfplumber for machine-generated PDFs. Falls back to
-    Tesseract OCR if pdfplumber returns insufficient text.
+    Args:
+        source: File path (str or Path) or raw PDF bytes.
+        ocr_enabled: Whether to attempt OCR on scanned pages. Defaults to True.
 
-    @spec INGEST-PDF-001
+    Returns:
+        ExtractionResult with extracted text, page count, and count of OCR'd pages.
+
+    Raises:
+        RuntimeError: If the PDF cannot be opened or yields no text at all.
+
+    @spec INGEST-PDF-001, INGEST-PDF-002
     """
-    raise NotImplementedError("PDF extraction not yet implemented — Phase 4")
+    ocr_available = ocr_enabled and _check_ocr_available()
+
+    if not ocr_available and ocr_enabled:
+        logger.info("OCR requested but not available — extracting text only")
+
+    if isinstance(source, bytes):
+        pdf_bytes = source
+        pdf_path = None
+        source_name = "<bytes>"
+    else:
+        pdf_path = Path(source)
+        pdf_bytes = None
+        source_name = pdf_path.name
+
+    pages_text: list[str] = []
+    ocr_pages: list[int] = []
+
+    try:
+        file_obj = io.BytesIO(pdf_bytes) if pdf_bytes is not None else str(pdf_path)
+        with pdfplumber.open(file_obj) as pdf:
+            page_count = len(pdf.pages)
+            if page_count == 0:
+                raise RuntimeError(f"PDF has no pages: {source_name}")
+
+            for i, page in enumerate(pdf.pages, start=1):
+                try:
+                    text = page.extract_text() or ""
+                    text = text.strip()
+                except Exception as e:
+                    logger.warning(f"Page {i} pdfplumber error in {source_name}: {e}")
+                    text = ""
+
+                if len(text) >= MIN_PAGE_TEXT_LENGTH:
+                    pages_text.append(text)
+                    continue
+
+                if ocr_available:
+                    logger.debug(f"Page {i} of {source_name}: insufficient text, attempting OCR")
+                    try:
+                        ocr_text = _ocr_page(pdf_bytes if pdf_bytes is not None else pdf_path, i)
+
+                        if len(ocr_text) >= MIN_PAGE_TEXT_LENGTH:
+                            pages_text.append(ocr_text)
+                            ocr_pages.append(i)
+                            logger.debug(
+                                f"Page {i} OCR success: {len(ocr_text)} chars"
+                            )
+                        else:
+                            pages_text.append(f"[Page {i}: OCR returned insufficient text]")
+                            ocr_pages.append(i)
+                            logger.warning(
+                                f"Page {i} of {source_name}: OCR returned only "
+                                f"{len(ocr_text)} chars"
+                            )
+                    except Exception as e:
+                        logger.warning(f"Page {i} OCR failed in {source_name}: {e}")
+                        pages_text.append(f"[Page {i}: OCR failed — {e}]")
+                else:
+                    pages_text.append(f"[Page {i}: image-only or insufficient text]")
+
+    except RuntimeError:
+        raise
+    except Exception as e:
+        raise RuntimeError(f"Failed to open PDF {source_name}: {e}") from e
+
+    full_text = PAGE_SEPARATOR.join(pages_text)
+
+    if not full_text.strip():
+        raise RuntimeError(
+            f"No text extracted from {source_name}. "
+            "The PDF may be fully scanned and OCR was unavailable or failed."
+        )
+
+    if ocr_pages:
+        logger.info(
+            f"{source_name}: OCR'd {len(ocr_pages)}/{page_count} pages: {ocr_pages[:10]}"
+            + ("..." if len(ocr_pages) > 10 else "")
+        )
+
+    logger.info(f"Extracted {len(full_text)} chars from {page_count} pages: {source_name}")
+    return ExtractionResult(
+        text=full_text,
+        page_count=page_count,
+        ocr_page_count=len(ocr_pages),
+    )

--- a/src/ingestion/manual_ingest.py
+++ b/src/ingestion/manual_ingest.py
@@ -45,8 +45,7 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
-import pdfplumber
-
+from src.ingestion.extractors.pdf_extractor import extract_text as extract_pdf
 from src.lib.supabase import (
     complete_ingestion_run,
     get_supabase_client,
@@ -88,13 +87,6 @@ DOC_TYPE_VOCAB = {
     "policy",
     "other",
 }
-
-# Page separator used in raw_content to join extracted page text
-PAGE_SEPARATOR = "\n\n---\n\n"
-
-# Minimum text length (characters) to consider a page successfully extracted
-MIN_PAGE_TEXT_LENGTH = 20
-
 
 # ─── Metadata resolution ──────────────────────────────────────────────────
 
@@ -248,72 +240,6 @@ def _resolve_metadata(pdf_path: Path, sidecar: dict[str, Any] | None) -> dict[st
     return meta
 
 
-# ─── PDF extraction ───────────────────────────────────────────────────────
-
-
-def extract_pdf_text(pdf_path: Path) -> tuple[str, int]:
-    """
-    Extract text from a PDF using pdfplumber.
-
-    Returns (extracted_text, page_count).
-
-    Pages are joined with PAGE_SEPARATOR. Pages with fewer than
-    MIN_PAGE_TEXT_LENGTH characters (likely scanned/image-only) are
-    replaced with a placeholder noting the page number.
-
-    Raises RuntimeError if the PDF cannot be opened or yields no text.
-
-    @spec INGEST-PDF-001
-    """
-    pages_text: list[str] = []
-    scanned_pages: list[int] = []
-
-    try:
-        with pdfplumber.open(str(pdf_path)) as pdf:
-            page_count = len(pdf.pages)
-            if page_count == 0:
-                raise RuntimeError(f"PDF has no pages: {pdf_path.name}")
-
-            for i, page in enumerate(pdf.pages, start=1):
-                try:
-                    text = page.extract_text() or ""
-                    text = text.strip()
-                except Exception as e:
-                    logger.warning(f"Page {i} extraction error in {pdf_path.name}: {e}")
-                    text = ""
-
-                if len(text) >= MIN_PAGE_TEXT_LENGTH:
-                    pages_text.append(text)
-                else:
-                    # Page likely scanned or image-only
-                    scanned_pages.append(i)
-                    pages_text.append(f"[Page {i}: image-only or insufficient text]")
-
-    except pdfplumber.exceptions.PDFSyntaxError as e:
-        raise RuntimeError(f"PDF syntax error in {pdf_path.name}: {e}") from e
-    except Exception as e:
-        raise RuntimeError(f"Failed to open PDF {pdf_path.name}: {e}") from e
-
-    full_text = PAGE_SEPARATOR.join(pages_text)
-
-    if not full_text.strip():
-        raise RuntimeError(
-            f"No text extracted from {pdf_path.name}. "
-            "The PDF may be fully scanned/image-based. "
-            "Run through OCR before ingesting."
-        )
-
-    if scanned_pages:
-        logger.warning(
-            f"{pdf_path.name}: {len(scanned_pages)}/{page_count} pages had "
-            f"insufficient text (possibly scanned): pages {scanned_pages[:10]}"
-            + ("..." if len(scanned_pages) > 10 else "")
-        )
-
-    logger.info(f"Extracted {len(full_text)} chars from {page_count} pages: {pdf_path.name}")
-    return full_text, page_count
-
-
 # ─── Ingestion logic ──────────────────────────────────────────────────────
 
 
@@ -370,23 +296,24 @@ def ingest_pdf(
     source_id = build_source_id(pdf_path, corpus_dir)
     result["source_id"] = source_id
 
-    # 4. Extract PDF text
+    # 4. Extract PDF text (with OCR fallback for scanned pages)
     try:
-        raw_content, page_count = extract_pdf_text(pdf_path)
+        extraction = extract_pdf(pdf_path)
     except RuntimeError as e:
         result["status"] = "error"
         result["error"] = str(e)
         logger.error(str(e))
         return result
 
-    # 5. Build raw_metadata
+    raw_content = extraction.text
     raw_metadata: dict[str, Any] = {
         "jurisdiction": meta["jurisdiction"],
         "doc_type": meta["doc_type"],
         "date": meta["date"],
         "source_url": meta["source_url"],
         "title": meta["title"],
-        "page_count": page_count,
+        "page_count": extraction.page_count,
+        "ocr_pages": extraction.ocr_page_count,
         "filename": pdf_path.name,
     }
     # Include optional fields if present

--- a/src/ingestion/scrapers/belair_legislation.py
+++ b/src/ingestion/scrapers/belair_legislation.py
@@ -14,13 +14,11 @@ links to PDF documents in the CivicPlus DocumentCenter.
 
 from __future__ import annotations
 
-import io
 import json
 import logging
 import time
 from dataclasses import asdict, dataclass
 
-import pdfplumber
 import requests
 from bs4 import BeautifulSoup
 
@@ -129,12 +127,17 @@ def scrape_legislation_page() -> list[LegislationEntry]:
     return entries
 
 
-def fetch_pdf_text(url: str, session: requests.Session) -> str | None:
+def fetch_pdf_text(url: str, session: requests.Session) -> tuple[str | None, int]:
     """
-    Download a PDF from a URL and extract its text content using pdfplumber.
+    Download a PDF from a URL and extract its text content.
 
-    Returns the extracted text, or None if the download or extraction fails.
+    Uses pdfplumber with OCR fallback for scanned documents.
+
+    Returns (extracted_text, ocr_page_count), or (None, 0) if the download
+    or extraction fails.
     """
+    from src.ingestion.extractors.pdf_extractor import extract_text
+
     try:
         logger.info(f"Downloading PDF: {url}")
         resp = session.get(url, timeout=30)
@@ -143,31 +146,21 @@ def fetch_pdf_text(url: str, session: requests.Session) -> str | None:
         content_type = resp.headers.get("content-type", "")
         if "pdf" not in content_type and not url.endswith(".pdf"):
             logger.debug(f"Skipping non-PDF response: {content_type}")
-            return None
+            return None, 0
 
-        with pdfplumber.open(io.BytesIO(resp.content)) as pdf:
-            pages = []
-            for page in pdf.pages:
-                text = page.extract_text()
-                if text:
-                    pages.append(text)
-
-            if not pages:
-                logger.warning(f"No text extracted from PDF: {url}")
-                return None
-
-            full_text = "\n\n".join(pages)
-            logger.info(
-                f"Extracted {len(full_text)} chars from {len(pages)} pages: {url}"
-            )
-            return full_text
+        result = extract_text(resp.content)
+        logger.info(
+            f"Extracted {len(result.text)} chars from {result.page_count} pages "
+            f"({result.ocr_page_count} OCR'd): {url}"
+        )
+        return result.text, result.ocr_page_count
 
     except requests.RequestException as e:
         logger.warning(f"Failed to download PDF {url}: {e}")
-        return None
+        return None, 0
     except Exception as e:
         logger.warning(f"Failed to extract text from PDF {url}: {e}")
-        return None
+        return None, 0
 
 
 def ingest_belair_legislation() -> None:
@@ -199,10 +192,11 @@ def ingest_belair_legislation() -> None:
         updated = 0
 
         for entry in entries:
-            # Try to extract full text from PDF
+            # Try to extract full text from PDF (with OCR fallback)
             pdf_text = None
+            ocr_page_count = 0
             if entry.pdf_url:
-                pdf_text = fetch_pdf_text(entry.pdf_url, session)
+                pdf_text, ocr_page_count = fetch_pdf_text(entry.pdf_url, session)
                 time.sleep(REQUEST_DELAY)
 
             # Use PDF text as raw_content if available, fall back to metadata JSON
@@ -213,6 +207,7 @@ def ingest_belair_legislation() -> None:
                     "item_type": entry.item_type,
                     "has_pdf": True,
                     "pdf_extracted": True,
+                    "ocr_pages": ocr_page_count,
                     "pdf_url": entry.pdf_url,
                     "title": entry.title,
                     "number": entry.number,

--- a/tests/ingestion/test_pdf_extractor.py
+++ b/tests/ingestion/test_pdf_extractor.py
@@ -1,0 +1,191 @@
+"""
+Tests for the PDF text extraction module with OCR fallback.
+
+@spec INGEST-PDF-001, INGEST-PDF-002
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ingestion.extractors.pdf_extractor import (
+    ExtractionResult,
+    MIN_PAGE_TEXT_LENGTH,
+    extract_text,
+)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def text_pdf(tmp_path):
+    """Create a simple text-based PDF using pdfplumber-compatible format."""
+    # We'll use a real minimal PDF with embedded text
+    # This is a minimal valid PDF with one page containing "Hello World"
+    pdf_content = (
+        b"%PDF-1.0\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n"
+        b"4 0 obj\n<< /Length 44 >>\nstream\n"
+        b"BT /F1 12 Tf 100 700 Td (Hello World Test PDF Content Here) Tj ET\n"
+        b"endstream\nendobj\n"
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n"
+        b"xref\n0 6\n"
+        b"0000000000 65535 f \n"
+        b"0000000009 00000 n \n"
+        b"0000000058 00000 n \n"
+        b"0000000115 00000 n \n"
+        b"0000000266 00000 n \n"
+        b"0000000360 00000 n \n"
+        b"trailer\n<< /Size 6 /Root 1 0 R >>\n"
+        b"startxref\n434\n%%EOF\n"
+    )
+    pdf_path = tmp_path / "text_test.pdf"
+    pdf_path.write_bytes(pdf_content)
+    return pdf_path
+
+
+@pytest.fixture
+def sample_scanned_pdf():
+    """Path to the sample scanned PDF from belairmd.org (if available)."""
+    path = Path("tmp/sample_scanned.pdf")
+    if not path.exists():
+        pytest.skip("Sample scanned PDF not available at tmp/sample_scanned.pdf")
+    return path
+
+
+# ─── Tests: text-based PDFs ──────────────────────────────────────────
+
+
+class TestTextPdfExtraction:
+    """Test extraction from machine-generated PDFs with embedded text."""
+
+    def test_extracts_text_from_path(self, text_pdf):
+        """pdfplumber successfully extracts text from a text-based PDF."""
+        result = extract_text(text_pdf, ocr_enabled=False)
+        assert isinstance(result, ExtractionResult)
+        assert result.page_count == 1
+        assert result.ocr_page_count == 0
+        assert "Hello World" in result.text
+
+    def test_extracts_text_from_bytes(self, text_pdf):
+        """Extraction works from raw bytes, not just file paths."""
+        pdf_bytes = text_pdf.read_bytes()
+        result = extract_text(pdf_bytes, ocr_enabled=False)
+        assert isinstance(result, ExtractionResult)
+        assert result.page_count == 1
+        assert "Hello World" in result.text
+
+    def test_no_ocr_when_text_sufficient(self, text_pdf):
+        """OCR is not invoked when pdfplumber extracts sufficient text."""
+        with patch(
+            "src.ingestion.extractors.pdf_extractor._ocr_page"
+        ) as mock_ocr:
+            result = extract_text(text_pdf, ocr_enabled=True)
+            mock_ocr.assert_not_called()
+            assert result.ocr_page_count == 0
+
+
+# ─── Tests: OCR fallback ────────────────────────────────────────────
+
+
+class TestOcrFallback:
+    """Test OCR fallback behavior for scanned pages."""
+
+    def test_ocr_triggers_on_insufficient_text(self):
+        """OCR is attempted when pdfplumber returns insufficient text."""
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = ""  # No text = scanned page
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page]
+        mock_pdf.__enter__ = MagicMock(return_value=mock_pdf)
+        mock_pdf.__exit__ = MagicMock(return_value=False)
+
+        with patch("pdfplumber.open", return_value=mock_pdf), \
+             patch(
+                 "src.ingestion.extractors.pdf_extractor._check_ocr_available",
+                 return_value=True,
+             ), \
+             patch(
+                 "src.ingestion.extractors.pdf_extractor._ocr_page",
+                 return_value="OCR extracted text from scanned page successfully",
+             ) as mock_ocr:
+            result = extract_text("/fake/path.pdf")
+            mock_ocr.assert_called_once_with(Path("/fake/path.pdf"), 1)
+            assert result.ocr_page_count == 1
+            assert "OCR extracted text" in result.text
+
+    def test_graceful_when_ocr_unavailable(self):
+        """Falls back to placeholder text when OCR deps not installed."""
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = ""
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page]
+        mock_pdf.__enter__ = MagicMock(return_value=mock_pdf)
+        mock_pdf.__exit__ = MagicMock(return_value=False)
+
+        with patch("pdfplumber.open", return_value=mock_pdf), \
+             patch(
+                 "src.ingestion.extractors.pdf_extractor._check_ocr_available",
+                 return_value=False,
+             ):
+            result = extract_text("/fake/path.pdf")
+            assert result.ocr_page_count == 0
+            assert "[Page 1:" in result.text
+
+    def test_ocr_disabled_flag(self, text_pdf):
+        """OCR is skipped entirely when ocr_enabled=False."""
+        with patch(
+            "src.ingestion.extractors.pdf_extractor._check_ocr_available"
+        ) as mock_check:
+            extract_text(text_pdf, ocr_enabled=False)
+            mock_check.assert_not_called()
+
+
+# ─── Tests: end-to-end with real scanned PDF ────────────────────────
+
+
+class TestScannedPdfEndToEnd:
+    """End-to-end test with actual scanned PDF from belairmd.org."""
+
+    def test_ocr_extracts_text_from_scanned_pdf(self, sample_scanned_pdf):
+        """OCR successfully extracts readable text from a scanned government PDF."""
+        result = extract_text(sample_scanned_pdf)
+        assert result.page_count == 10
+        assert result.ocr_page_count == 10  # All pages are scanned
+        assert len(result.text) > 1000  # Should get substantial text
+        # The document is about an annexation petition
+        assert "annex" in result.text.lower() or "petition" in result.text.lower()
+
+    def test_ocr_from_bytes(self, sample_scanned_pdf):
+        """OCR works when PDF is provided as bytes (simulating download)."""
+        pdf_bytes = sample_scanned_pdf.read_bytes()
+        result = extract_text(pdf_bytes)
+        assert result.page_count == 10
+        assert result.ocr_page_count == 10
+        assert len(result.text) > 1000
+
+
+# ─── Tests: error handling ───────────────────────────────────────────
+
+
+class TestErrorHandling:
+    """Test error handling for invalid/corrupt PDFs."""
+
+    def test_raises_on_empty_pdf(self, tmp_path):
+        """Raises RuntimeError for files that aren't valid PDFs."""
+        bad_pdf = tmp_path / "empty.pdf"
+        bad_pdf.write_bytes(b"not a pdf")
+        with pytest.raises(RuntimeError):
+            extract_text(bad_pdf)
+
+    def test_raises_on_nonexistent_file(self):
+        """Raises RuntimeError for missing files."""
+        with pytest.raises(RuntimeError):
+            extract_text("/nonexistent/path.pdf")


### PR DESCRIPTION
Government documents from belairmd.org DocumentCenter are often scanned photocopies with no extractable text. This implements the pdf_extractor module (previously a Phase 4 stub) with pdfplumber as primary extractor and pytesseract OCR as per-page fallback for scanned pages.

- Implement pdf_extractor.py with hybrid pdfplumber + OCR extraction
- Refactor manual_ingest.py and belair_legislation.py to use shared extractor
- Add pytesseract, pdf2image, Pillow to requirements.txt
- Add 10 tests including end-to-end validation with real scanned PDF
- Track ocr_pages count in raw_metadata for downstream awareness