### PR TITLE
ci: disable automatic triggers, make workflows dispatch-only

### DIFF
--- a/.github/workflows/gardener.yml
+++ b/.github/workflows/gardener.yml
@@ -13,12 +13,6 @@
 name: Gardener
 
 on:
-  schedule:
-    # Weekly: Monday at 12:00 UTC (7:00 AM ET)
-    - cron: '0 12 * * 1'
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       deploy_url:

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -9,11 +9,6 @@
 name: Data Ingestion Pipeline
 
 on:
-  schedule:
-    # State legislative data: every 6 hours
-    - cron: '0 */6 * * *'
-    # Local data scraping: daily at 11:00 UTC (6:00 AM ET)
-    - cron: '0 11 * * *'
   workflow_dispatch:
     inputs:
       source:


### PR DESCRIPTION
Removes schedule and pull_request triggers from both gardener.yml and
ingest.yml. Both workflows now only run on manual workflow_dispatch.

https://claude.ai/code/session_01Lno8q6Zvw2abQWKGczDHh6